### PR TITLE
Fix support for templated sender information in SparkPost

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^5.6|^7.0",
         "psr/log": "^1.0",
-        "quartzy/php-email": "0.1.0"
+        "quartzy/php-email": "0.2.0"
     },
     "require-dev": {
         "sendgrid/sendgrid": "^5.1",

--- a/src/Exceptions/ValidationException.php
+++ b/src/Exceptions/ValidationException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Courier\Exceptions;
+
+class ValidationException extends \RuntimeException implements CourierException
+{
+}

--- a/src/SparkPostCourier.php
+++ b/src/SparkPostCourier.php
@@ -293,13 +293,7 @@ class SparkPostCourier
 
                         $inlineEmail->setReplyTos($email->getReplyTos()[0]);
                     } else {
-                        if ($parts = explode(' ', $template[self::REPLY_TO])) {
-                            $email = trim(array_pop($parts), '<>');
-                            // Be sure to trim any extraneous quotes from the name
-                            $name  = trim(implode(' ', $parts), '"');
-
-                            $inlineEmail->setReplyTos(new Address($email, $name));
-                        }
+                        $inlineEmail->setReplyTos(Address::fromString($template[self::REPLY_TO]));
                     }
                 }
 

--- a/src/SparkPostCourier.php
+++ b/src/SparkPostCourier.php
@@ -273,7 +273,7 @@ class SparkPostCourier
                     ->setSubject($template[self::SUBJECT]);
 
                 // If the from contains a templated from, it should be actively replaced now to avoid validation errors.
-                if (strpos('{{', $template[self::FROM][self::CONTACT_EMAIL]) !== false) {
+                if (strpos($template[self::FROM][self::CONTACT_EMAIL], '{{') !== false) {
                     $inlineEmail->setFrom($email->getFrom());
                 } else {
                     $inlineEmail->setFrom(
@@ -284,9 +284,9 @@ class SparkPostCourier
                     );
                 }
 
-                // If the form contains templated replyTo it should be replaced now to avoid validation errors.
+                // If the form contains a templated replyTo, it should be actively replaced now to avoid validation errors.
                 if (array_key_exists(self::REPLY_TO, $template)) {
-                    if (strpos('{{', $template[self::REPLY_TO]) !== false) {
+                    if (strpos($template[self::REPLY_TO], '{{') !== false) {
                         if (empty($email->getReplyTos())) {
                             throw new ValidationException('Reply to is templated but no value was given');
                         }


### PR DESCRIPTION
When sending templated content through SparkPost with attachments, the code
has to pull down the template and recreate it as an inline template. If the
template includes templated sender information the courier should actively
replace it with the information on the Email to ensure validation errors are
not thrown