### PR TITLE
Fix SparkPost recipient list to be inclusive

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,27 @@ SparkPost allows users to define templated keys in the from, reply to, and subje
 * `fromName`
 * `replyTo`
 * `subject`
+* `ccHeader`
 
 These will be added to the template data already defined in the `TemplatedContent` assuming the keys are not already set manually.
+
+##### Temporary fix for correctly displaying CC header
+
+As documented in this [post](https://www.sparkpost.com/docs/faq/cc-bcc-with-rest-api/), the SparkPost API requires sending the `CC` header information in order to properly display recipients. In the context of inline templates and non-templated emails, setting this header works fine. However, if sending a standard templated email, SparkPost's API does not respect the `CC` header. To work around this, Courier will set the `ccHeader` variable in the substitution data to what the value _should_ be. In order to leverage this variable, you will need to update your template using the API (the header attributes are not available in the web editor) to include the value. This can be done with a request like:
+
+```json
+PUT https://api.sparkpost.com/api/v1/templates/my-template-id
+
+{
+  "content": {
+    // All of your other content must go here as this PUT will overwrite all other content
+    "headers": {
+      "CC": "{{ccHeader}}"
+    }
+  }
+}
+
+```
 
 #### Postmark
 

--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ These will be added to the template data already defined in the `TemplatedConten
 
 As documented in this [post](https://www.sparkpost.com/docs/faq/cc-bcc-with-rest-api/), the SparkPost API requires sending the `CC` header information in order to properly display recipients. In the context of inline templates and non-templated emails, setting this header works fine. However, if sending a standard templated email, SparkPost's API does not respect the `CC` header. To work around this, Courier will set the `ccHeader` variable in the substitution data to what the value _should_ be. In order to leverage this variable, you will need to update your template using the API (the header attributes are not available in the web editor) to include the value. This can be done with a request like:
 
-```json
-PUT https://api.sparkpost.com/api/v1/templates/my-template-id
+```javascript
+// PUT https://api.sparkpost.com/api/v1/templates/my-template-id
 
 {
   "content": {

--- a/tests/SparkPostCourierTest.php
+++ b/tests/SparkPostCourierTest.php
@@ -76,6 +76,9 @@ class SparkPostCourierTest extends TestCase
                     'name'  => null,
                     'email' => 'sender@test.com',
                 ],
+                'headers'     => [
+                    'CC' => '',
+                ],
                 'subject'     => 'Subject',
                 'html'        => null,
                 'text'        => 'This is a test email',
@@ -85,8 +88,8 @@ class SparkPostCourierTest extends TestCase
             'recipients' => [
                 [
                     'address' => [
-                        'name'  => null,
-                        'email' => 'recipient@test.com',
+                        'email'     => 'recipient@test.com',
+                        'header_to' => 'recipient@test.com',
                     ],
                 ],
             ],
@@ -117,6 +120,9 @@ class SparkPostCourierTest extends TestCase
                     'name'  => null,
                     'email' => 'sender@test.com',
                 ],
+                'headers'     => [
+                    'CC' => '',
+                ],
                 'subject'     => 'Subject',
                 'html'        => '',
                 'text'        => '',
@@ -126,8 +132,8 @@ class SparkPostCourierTest extends TestCase
             'recipients' => [
                 [
                     'address' => [
-                        'name'  => null,
-                        'email' => 'recipient@test.com',
+                        'email'     => 'recipient@test.com',
+                        'header_to' => 'recipient@test.com',
                     ],
                 ],
             ],
@@ -157,6 +163,9 @@ class SparkPostCourierTest extends TestCase
         $expectedArray = [
             'content'           => [
                 'template_id' => '1234',
+                'headers'     => [
+                    'CC' => '',
+                ],
             ],
             'substitution_data' => [
                 'test'        => 'value',
@@ -165,12 +174,13 @@ class SparkPostCourierTest extends TestCase
                 'fromDomain'  => 'test.com',
                 'subject'     => 'Subject',
                 'replyTo'     => 'reply.to@test.com',
+                'ccHeader'    => '',
             ],
             'recipients'        => [
                 [
                     'address' => [
-                        'name'  => null,
-                        'email' => 'recipient@test.com',
+                        'email'     => 'recipient@test.com',
+                        'header_to' => 'recipient@test.com',
                     ],
                 ],
             ],
@@ -235,7 +245,10 @@ class SparkPostCourierTest extends TestCase
                     ],
                 ],
                 'reply_to'    => '"Template Replier" <template.replier@test.com>',
-                'headers'     => ['X-Header' => 'test'],
+                'headers'     => [
+                    'X-Header' => 'test',
+                    'CC'       => '',
+                ],
             ],
             'substitution_data' => [
                 'test'        => 'value',
@@ -243,12 +256,13 @@ class SparkPostCourierTest extends TestCase
                 'fromEmail'   => 'sender',
                 'fromDomain'  => 'test.com',
                 'subject'     => 'Subject',
+                'ccHeader'    => '',
             ],
             'recipients'        => [
                 [
                     'address' => [
-                        'name'  => null,
-                        'email' => 'recipient@test.com',
+                        'email'     => 'recipient@test.com',
+                        'header_to' => 'recipient@test.com',
                     ],
                 ],
             ],
@@ -315,7 +329,10 @@ class SparkPostCourierTest extends TestCase
                     ],
                 ],
                 'reply_to'    => 'dynamic@replyto.com',
-                'headers'     => ['X-Header' => 'test'],
+                'headers'     => [
+                    'X-Header' => 'test',
+                    'CC'       => '',
+                ],
             ],
             'substitution_data' => [
                 'test'        => 'value',
@@ -324,12 +341,13 @@ class SparkPostCourierTest extends TestCase
                 'fromDomain'  => 'test.com',
                 'subject'     => 'Subject',
                 'replyTo'     => 'dynamic@replyto.com',
+                'ccHeader'    => '',
             ],
             'recipients'        => [
                 [
                     'address' => [
-                        'name'  => null,
-                        'email' => 'recipient@test.com',
+                        'email'     => 'recipient@test.com',
+                        'header_to' => 'recipient@test.com',
                     ],
                 ],
             ],
@@ -434,6 +452,9 @@ class SparkPostCourierTest extends TestCase
                     'name'  => null,
                     'email' => 'sender@test.com',
                 ],
+                'headers'     => [
+                    'CC' => '"CC" <cc@test.com>',
+                ],
                 'subject'     => 'This is the Subject',
                 'html'        => 'This is the html email',
                 'text'        => 'This is the text email',
@@ -449,24 +470,20 @@ class SparkPostCourierTest extends TestCase
             'recipients' => [
                 [
                     'address' => [
-                        'name'  => null,
-                        'email' => 'recipient@test.com',
+                        'email'     => 'recipient@test.com',
+                        'header_to' => 'recipient@test.com',
                     ],
                 ],
-            ],
-            'cc' => [
                 [
                     'address' => [
-                        'name'  => 'CC',
-                        'email' => 'cc@test.com',
+                        'email'     => 'cc@test.com',
+                        'header_to' => 'recipient@test.com',
                     ],
                 ],
-            ],
-            'bcc' => [
                 [
                     'address' => [
-                        'name'  => 'BCC',
-                        'email' => 'bcc@test.com',
+                        'email'     => 'bcc@test.com',
+                        'header_to' => 'recipient@test.com',
                     ],
                 ],
             ],
@@ -498,6 +515,9 @@ class SparkPostCourierTest extends TestCase
                     'name'  => null,
                     'email' => 'sender@test.com',
                 ],
+                'headers'     => [
+                    'CC' => '',
+                ],
                 'subject'     => 'Subject',
                 'html'        => '',
                 'text'        => '',
@@ -507,8 +527,8 @@ class SparkPostCourierTest extends TestCase
             'recipients' => [
                 [
                     'address' => [
-                        'name'  => null,
-                        'email' => 'recipient@test.com',
+                        'email'     => 'recipient@test.com',
+                        'header_to' => 'recipient@test.com',
                     ],
                 ],
             ],


### PR DESCRIPTION
This PR will result in emails sent through SparkPost having a single recipient
list defined using headers as described [here](https://www.sparkpost.com/docs/faq/cc-bcc-with-rest-api/). The end result is that
instead of each recipient receiving an email only showing their own address,
the recipients will see all other "to" recipients as well as the "CC"
recipients.