### PR TITLE
Upgrade to php-email 0.5 and handle BC incompatible changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project attempts to follow [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Changed
+
+* Upgrade to [php-email](https://github.com/quartzy/php-email) version 0.5.0.
+* Update use of `SimpleContent` to handle BC incompatible changes from php-email.
+
 ## 0.3.0 - 2017-12-13
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^7.1",
         "psr/log": "^1.0",
-        "quartzy/php-email": "^0.4.0"
+        "quartzy/php-email": "^0.5.0"
     },
     "require-dev": {
         "sendgrid/sendgrid": "^5.1",

--- a/src/PostmarkCourier.php
+++ b/src/PostmarkCourier.php
@@ -92,7 +92,11 @@ class PostmarkCourier implements ConfirmingCourier
                 break;
 
             case $content instanceof Content\SimpleContent:
-                $response = $this->sendNonTemplateEmail($email, $content->getHtml(), $content->getText());
+                $response = $this->sendNonTemplateEmail(
+                    $email,
+                    $content->getHtml()->getBody(),
+                    $content->getText()->getBody()
+                );
                 break;
 
             case $content instanceof Content\EmptyContent:

--- a/src/SendGridCourier.php
+++ b/src/SendGridCourier.php
@@ -260,9 +260,9 @@ class SendGridCourier implements ConfirmingCourier
         Content\Contracts\SimpleContent $content
     ): SendGrid\Response {
         if ($content->getHtml() !== null) {
-            $email->addContent(new SendGrid\Content('text/html', $content->getHtml()));
+            $email->addContent(new SendGrid\Content('text/html', $content->getHtml()->getBody()));
         } elseif ($content->getText() !== null) {
-            $email->addContent(new SendGrid\Content('text/plain', $content->getText()));
+            $email->addContent(new SendGrid\Content('text/plain', $content->getText()->getBody()));
         } else {
             $email->addContent(new SendGrid\Content('text/plain', ''));
         }

--- a/src/SparkPostCourier.php
+++ b/src/SparkPostCourier.php
@@ -375,18 +375,17 @@ class SparkPostCourier implements ConfirmingCourier
      */
     protected function getInlineContent(array $template): Content\SimpleContent
     {
-        $htmlContent = array_key_exists(self::HTML, $template) ? $template[self::HTML] : null;
-        $textContent = array_key_exists(self::TEXT, $template) ? $template[self::TEXT] : null;
-
-        if ($htmlContent !== null && $textContent !== null) {
-            return Content\SimpleContent::html($htmlContent)->addText($textContent);
-        } elseif ($htmlContent !== null) {
-            return Content\SimpleContent::html($htmlContent);
-        } elseif ($textContent !== null) {
-            return Content\SimpleContent::text($textContent);
+        $htmlContent = null;
+        if (array_key_exists(self::HTML, $template)) {
+            $htmlContent = new Content\SimpleContent\Message($template[self::HTML]);
         }
 
-        return Content\SimpleContent::html('');
+        $textContent = null;
+        if (array_key_exists(self::TEXT, $template)) {
+            $textContent = new Content\SimpleContent\Message($template[self::TEXT]);
+        }
+
+        return new Content\SimpleContent($htmlContent, $textContent);
     }
 
     /**

--- a/src/SparkPostCourier.php
+++ b/src/SparkPostCourier.php
@@ -392,9 +392,9 @@ class SparkPostCourier implements ConfirmingCourier
      *
      * @param Email $email
      *
-     * @return array
-     *
      * @throws TransmissionException
+     *
+     * @return array
      */
     private function getTemplate(Email $email): array
     {

--- a/src/SparkPostCourier.php
+++ b/src/SparkPostCourier.php
@@ -275,8 +275,7 @@ class SparkPostCourier implements ConfirmingCourier
              * we will instead get the template from SparkPost and create a new inline template using the information
              * from it instead.
              */
-            $template = $this->getTemplate($email);
-
+            $template    = $this->getTemplate($email);
             $inlineEmail = clone $email;
 
             $inlineEmail
@@ -394,6 +393,8 @@ class SparkPostCourier implements ConfirmingCourier
      * @param Email $email
      *
      * @return array
+     *
+     * @throws TransmissionException
      */
     private function getTemplate(Email $email): array
     {

--- a/tests/PostmarkCourierTest.php
+++ b/tests/PostmarkCourierTest.php
@@ -64,7 +64,7 @@ class PostmarkCourierTest extends TestCase
             ->to('receiver@test.com')
             ->to('other@test.com')
             ->withSubject('Test From Postmark API')
-            ->withContent(new SimpleContent('<b>Test from Postmark</b>', 'Test from Postmark'))
+            ->withContent(SimpleContent::html('<b>Test from Postmark</b>')->addText('Test from Postmark'))
             ->cc('copy@test.com')
             ->bcc('blind.copy@test.com')
             ->replyTo('reply.to@test.com', 'Replier')

--- a/tests/SparkPostCourierTest.php
+++ b/tests/SparkPostCourierTest.php
@@ -586,7 +586,7 @@ class SparkPostCourierTest extends TestCase
 
         $email = new Email(
             'This is the Subject',
-            new SimpleContent('This is the html email', 'This is the text email'),
+            SimpleContent::html('This is the html email')->addText('This is the text email'),
             new Address('sender@test.com'),
             [new Address('recipient@test.com')]
         );


### PR DESCRIPTION
The constructor and static constructor functions on `Email` have been
altered with the latest release of php-email. This PR just updates the
version of the dependency and handles these BC-incompatible changes.
Further changes for the new release will come later.